### PR TITLE
Added wifi interface option to ansible/hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ ansible-playbook robots-local.yaml -K
   ```
   nmcli connection up netplan-wlp58s0-robotont-1
   ```
+  * If there is an error activating or starting the Wifi Check if the Ubuntu desktop Manager if the Wifi Interface is enabled. The Ansible installation also installs on a server installation a minimal Desktop environment. 
 # Laptop setup: 2 laptops and two memory sticks are needed
 #### Boot linux in trial mode from the installation memory stick
 #### Then copy scripts from main laptop to the one which installs ubuntu

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ git clone https://github.com/robotont/robotont-setup
 ```
 6) Adjust the file **hosts** in the ansible folder of the repository. Repository is the **robotont-setup** folder you've downloaded with a command. Edit the second line and enter the password of the access point you would like to have **wifi_pass=** ***your_password***. The robot will become a WiFi access point after configuration is finished with the password specified by you.
    * Additional step for custom username(if you are using peko skip it). Modify the first line in hosts file **ansible_user=peko** and replace peko with your username
+   * You must also specify the WiFi interface used for the access point. to find out which interfaces are available, use the following command.
+
+      ```
+      nmcli --get-values GENERAL.DEVICE,GENERAL.TYPE device show
+      ```
+      replace the wifi_interface=wlo1 with the interface name you want to use.
+   
 7) Run the following command to install ansible:
 <!-- ```
 sudo apt install python3-pip

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,8 +1,9 @@
 [local]
-localhost id=1 ansible_user=peko wifi_pass=12345678 is_robot=1
+localhost id=1 ansible_user=peko wifi_pass=12345678 is_robot=1 wifi_interface=wlo1 
+
 
 [robots]
-192.168.200.8 id=8 ansible_user=peko wifi_pass= is_robot=1 ansible_password= ansible_sudo_pass=
+#192.168.200.8 id=8 ansible_user=peko wifi_interface= wifi_pass= is_robot=1 ansible_password= ansible_sudo_pass=
 #192.168.88.221 id=5 ansible_user=peko wifi_pass= is_robot=1
 #192.168.88.4 id=4 ansible_user=robot wifi_pass=12334567
 #
@@ -10,10 +11,10 @@ localhost id=1 ansible_user=peko wifi_pass=12345678 is_robot=1
 #192.168.200.3 id=3 ansible_user=peko
 
 [robots-netplan]
-192.168.200.8 id=8 ansible_user=peko wifi_pass= ansible_password= ansible_sudo_pass=
+#192.168.200.8 id=8 ansible_user=peko wifi_pass= ansible_password= ansible_sudo_pass=
 
 [laptops]
-192.168.156.212 id=1 ansible_user=peko ansible_password=
+#192.168.156.212 id=1 ansible_user=peko ansible_password=
 #192.168.88.4 id=1 ansible_user=robot
 #laptop-2 id=2 ansible_user=peko
 #laptop-3 id=3 ansible_user=peko

--- a/ansible/roles/robots-update/tasks/main.yaml
+++ b/ansible/roles/robots-update/tasks/main.yaml
@@ -37,8 +37,14 @@
   command: netplan apply
   become: true
 
+
+- name: start wifi
+  command: ip link set {{ wifi_interface }} up
+  become: true
+
+
 - name: Apply connection
-  command: nmcli connection up netplan-wlp58s0-robotont-{{ id }}
+  command: nmcli connection up netplan-{{ wifi_interface }}-robotont-{{ id }}
   become: true
 
 - name: Unconditionally reboot the machine with all defaults

--- a/ansible/roles/robots/tasks/main.yaml
+++ b/ansible/roles/robots/tasks/main.yaml
@@ -166,8 +166,14 @@
   command: netplan apply
   become: true
 
+
+- name: start wifi
+  command: ip link set {{ wifi_interface }} up
+  become: true
+
+
 - name: Apply connection
-  command: nmcli connection up netplan-wlp58s0-robotont-{{ id }}
+  command: nmcli connection up netplan-{{ wifi_interface }}-robotont-{{ id }}
   become: true
 
 - name: Unconditionally reboot the machine with all defaults

--- a/ansible/roles/robots/tasks/main.yaml
+++ b/ansible/roles/robots/tasks/main.yaml
@@ -176,6 +176,11 @@
   command: nmcli connection up netplan-{{ wifi_interface }}-robotont-{{ id }}
   become: true
 
+
+- name: Disable Sleep and Hibernate
+  command: systemctl unmask sleep.target suspend.target hibernate.target hybrid-sleep.target
+  become: true
+
 - name: Unconditionally reboot the machine with all defaults
   reboot:
   become: yes

--- a/ansible/roles/robots/tasks/main.yaml
+++ b/ansible/roles/robots/tasks/main.yaml
@@ -183,5 +183,5 @@
 
 - name: Unconditionally reboot the machine with all defaults
   reboot:
-  become: yes
+  become: true
 

--- a/ansible/templates/Testik_netplan.j2
+++ b/ansible/templates/Testik_netplan.j2
@@ -3,7 +3,7 @@ network:
   version: 2
   renderer: NetworkManager
   wifis:
-    wlp58s0:
+    {{ wifi_interface }}:
       dhcp4: no
       addresses:
         - 192.168.200.{{ id }}/24


### PR DESCRIPTION
the latest generation of Intell nuc's is no longer compact with the setup files. The Wifi interface for the hotspot was not recognised, which is why the installation failed. 
With these changes, the wifi interface can now be adjusted via the ansible/hosts file which should make the installation more independent of the hardware platform.